### PR TITLE
feat: add Claude Opus 4.8 support and set as default model

### DIFF
--- a/bods.go
+++ b/bods.go
@@ -199,7 +199,7 @@ func (b *Bods) startMessagesCmd(content string) tea.Cmd {
 			// b.Config.ModelID = ClaudeV4Sonnet.String()
 			// b.Config.ModelID = ClaudeV45Sonnet.String()
 			// b.Config.ModelID = ClaudeV46Opus.String()
-			b.Config.ModelID = ClaudeV47Opus.String()
+			b.Config.ModelID = ClaudeV48Opus.String()
 		}
 		logger.Println("config.ModelID set to: ", b.Config.ModelID)
 
@@ -259,7 +259,7 @@ func (b *Bods) startMessagesCmd(content string) tea.Cmd {
 		logger.Printf("b.Config.Think=%t b.Config.EnableTextEditor=%t b.Config.ModelID=%s", b.Config.Think, b.Config.EnableTextEditor, b.Config.ModelID)
 
 		normalizedModelID := normalizeToModelID(b.Config.ModelID)
-		if b.Config.Think && (normalizedModelID == ClaudeV37Sonnet.String() || normalizedModelID == ClaudeV4Sonnet.String() || normalizedModelID == ClaudeV4Opus.String() || normalizedModelID == ClaudeV45Sonnet.String() || normalizedModelID == ClaudeV45Haiku.String() || normalizedModelID == ClaudeV45Opus.String() || normalizedModelID == ClaudeV46Opus.String() || normalizedModelID == ClaudeV47Opus.String() || normalizedModelID == ClaudeV46Sonnet.String()) {
+		if b.Config.Think && (normalizedModelID == ClaudeV37Sonnet.String() || normalizedModelID == ClaudeV4Sonnet.String() || normalizedModelID == ClaudeV4Opus.String() || normalizedModelID == ClaudeV45Sonnet.String() || normalizedModelID == ClaudeV45Haiku.String() || normalizedModelID == ClaudeV45Opus.String() || normalizedModelID == ClaudeV46Opus.String() || normalizedModelID == ClaudeV47Opus.String() || normalizedModelID == ClaudeV46Sonnet.String() || normalizedModelID == ClaudeV48Opus.String()) {
 			if IsAdaptiveThinkingModel(normalizedModelID) {
 				paramsMessagesAPI.Thinking = NewAdaptiveThinkingConfig()
 				logger.Println("enabled adaptive thinking for", normalizedModelID)
@@ -299,13 +299,13 @@ func (b *Bods) startMessagesCmd(content string) tea.Cmd {
 		textEditorContext := ""
 		if b.Config.EnableTextEditor {
 			modelID := normalizeToModelID(b.Config.ModelID)
-			// Text editor tool is only supported by Claude 3.5v2 Sonnet, Claude 3.7 Sonnet, Claude 4, Claude 4.5, Claude 4.6, and Claude 4.7
-			if modelID == ClaudeV35SonnetV2.String() || modelID == ClaudeV37Sonnet.String() || modelID == ClaudeV4Sonnet.String() || modelID == ClaudeV4Opus.String() || modelID == ClaudeV45Sonnet.String() || modelID == ClaudeV45Haiku.String() || modelID == ClaudeV45Opus.String() || modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String() {
+			// Text editor tool is only supported by Claude 3.5v2 Sonnet, Claude 3.7 Sonnet, Claude 4, Claude 4.5, Claude 4.6, Claude 4.7, and Claude 4.8
+			if modelID == ClaudeV35SonnetV2.String() || modelID == ClaudeV37Sonnet.String() || modelID == ClaudeV4Sonnet.String() || modelID == ClaudeV4Opus.String() || modelID == ClaudeV45Sonnet.String() || modelID == ClaudeV45Haiku.String() || modelID == ClaudeV45Opus.String() || modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String() || modelID == ClaudeV48Opus.String() {
 
 				switch {
 				case modelID == ClaudeV35SonnetV2.String():
 					paramsMessagesAPI.AnthropicBeta = append(paramsMessagesAPI.AnthropicBeta, "computer-use-2024-10-22")
-				case (modelID == ClaudeV4Sonnet.String() || modelID == ClaudeV4Opus.String() || modelID == ClaudeV45Sonnet.String() || modelID == ClaudeV45Haiku.String() || modelID == ClaudeV45Opus.String() || modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String()) && b.Config.Think:
+				case (modelID == ClaudeV4Sonnet.String() || modelID == ClaudeV4Opus.String() || modelID == ClaudeV45Sonnet.String() || modelID == ClaudeV45Haiku.String() || modelID == ClaudeV45Opus.String() || modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String() || modelID == ClaudeV48Opus.String()) && b.Config.Think:
 					paramsMessagesAPI.AnthropicBeta = append(paramsMessagesAPI.AnthropicBeta, "interleaved-thinking-2025-05-14")
 				default: // for Claude 3.7
 					paramsMessagesAPI.AnthropicBeta = append(paramsMessagesAPI.AnthropicBeta, "token-efficient-tools-2025-02-19")
@@ -348,7 +348,7 @@ func (b *Bods) startMessagesCmd(content string) tea.Cmd {
 			}
 		}
 
-		// Add effort parameter support for Claude Opus 4.5/4.6/4.7
+		// Add effort parameter support for Claude Opus 4.5/4.6/4.7/4.8
 		if b.Config.Effort != "" {
 			const errLabelEffortParameter = "EffortParameter"
 
@@ -358,8 +358,8 @@ func (b *Bods) startMessagesCmd(content string) tea.Cmd {
 			// Validate model support
 			normalizedModelID := normalizeToModelID(b.Config.ModelID)
 			if !IsEffortParamSupported(normalizedModelID) {
-				e := fmt.Errorf("effort parameter is only supported by Claude Opus 4.5/4.6/4.7 (model IDs: %s, %s, %s), but you are using: %s",
-					ClaudeV45Opus.String(), ClaudeV46Opus.String(), ClaudeV47Opus.String(), b.Config.ModelID)
+				e := fmt.Errorf("effort parameter is only supported by Claude Opus 4.5/4.6/4.7/4.8 (model IDs: %s, %s, %s, %s), but you are using: %s",
+					ClaudeV45Opus.String(), ClaudeV46Opus.String(), ClaudeV47Opus.String(), ClaudeV48Opus.String(), b.Config.ModelID)
 				return bodsError{e, errLabelEffortParameter}
 			}
 
@@ -370,21 +370,24 @@ func (b *Bods) startMessagesCmd(content string) tea.Cmd {
 				return bodsError{e, errLabelEffortParameter}
 			}
 
-			// Validate "max" is only used with Opus 4.6 or 4.7
-			if b.Config.Effort == EffortMax && !IsOpus46Model(normalizedModelID) && !IsOpus47Model(normalizedModelID) {
-				e := fmt.Errorf("effort level 'max' is only supported by Claude Opus 4.6 and 4.7, but you are using: %s", b.Config.ModelID)
+			// Validate "max" is only used with Opus 4.6, 4.7, or 4.8
+			if b.Config.Effort == EffortMax && !IsOpus46Model(normalizedModelID) && !IsOpus47Model(normalizedModelID) && !IsOpus48Model(normalizedModelID) {
+				e := fmt.Errorf("effort level 'max' is only supported by Claude Opus 4.6, 4.7, and 4.8, but you are using: %s", b.Config.ModelID)
 				return bodsError{e, errLabelEffortParameter}
 			}
 
-			// Validate "xhigh" is only used with Opus 4.7
-			if b.Config.Effort == EffortXHigh && !IsOpus47Model(normalizedModelID) {
-				e := fmt.Errorf("effort level 'xhigh' is only supported by Claude Opus 4.7, but you are using: %s", b.Config.ModelID)
+			// Validate "xhigh" is only used with Opus 4.7 or 4.8
+			if b.Config.Effort == EffortXHigh && !IsOpus47Model(normalizedModelID) && !IsOpus48Model(normalizedModelID) {
+				e := fmt.Errorf("effort level 'xhigh' is only supported by Claude Opus 4.7 and 4.8, but you are using: %s", b.Config.ModelID)
 				return bodsError{e, errLabelEffortParameter}
 			}
 
-			// Add beta header if not already present
-			if !slices.Contains(paramsMessagesAPI.AnthropicBeta, "effort-2025-11-24") {
-				paramsMessagesAPI.AnthropicBeta = append(paramsMessagesAPI.AnthropicBeta, "effort-2025-11-24")
+			// Beta header for effort is only required for Opus 4.5 (private beta).
+			// Opus 4.6, 4.7, and 4.8 use the effort parameter natively without a beta header.
+			if normalizedModelID == ClaudeV45Opus.String() {
+				if !slices.Contains(paramsMessagesAPI.AnthropicBeta, "effort-2025-11-24") {
+					paramsMessagesAPI.AnthropicBeta = append(paramsMessagesAPI.AnthropicBeta, "effort-2025-11-24")
+				}
 			}
 
 			// Set output config

--- a/main.go
+++ b/main.go
@@ -259,7 +259,7 @@ func initFlags() {
 		flagEffort         = "effort" // effort level for Claude Opus 4.5
 	)
 
-	rootCmd.PersistentFlags().StringVarP(&config.ModelID, flagModel, string(flagModel[0]), "", "The specific foundation model to use (default is claude-opus-4.7)")
+	rootCmd.PersistentFlags().StringVarP(&config.ModelID, flagModel, string(flagModel[0]), "", "The specific foundation model to use (default is claude-opus-4.8)")
 	_ = rootCmd.RegisterFlagCompletionFunc(flagModel,
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return AnthrophicModelsIDs, cobra.ShellCompDirectiveDefault
@@ -291,10 +291,10 @@ func initFlags() {
 		rootCmd.PersistentFlags().BoolVarP(&config.Pasteboard, flagClipboard, "P", false, "Get image form pasteboard (clipboard)")
 	}
 
-	rootCmd.PersistentFlags().BoolVarP(&config.Think, flagThink, "k", false, "Enable thinking (extended for 3.7-4.5, adaptive for Opus 4.6/4.7)")
-	rootCmd.PersistentFlags().IntVarP(&config.BudgetTokens, flagBudget, string(flagBudget[0]), 0, fmt.Sprintf("Thinking token budget for Claude 3.7-4.5; ignored for Opus 4.6/4.7, use --effort instead (default=%d)", defaultThinkingTokens))
+	rootCmd.PersistentFlags().BoolVarP(&config.Think, flagThink, "k", false, "Enable thinking (extended for 3.7-4.5, adaptive for Opus 4.6/4.7/4.8)")
+	rootCmd.PersistentFlags().IntVarP(&config.BudgetTokens, flagBudget, string(flagBudget[0]), 0, fmt.Sprintf("Thinking token budget for Claude 3.7-4.5; ignored for Opus 4.6/4.7/4.8, use --effort instead (default=%d)", defaultThinkingTokens))
 	rootCmd.PersistentFlags().BoolVarP(&config.EnableTextEditor, flagTextEditor, "e", false, "Enable text editor tool for Claude to view and modify files")
-	rootCmd.PersistentFlags().StringVarP(&config.Effort, flagEffort, "E", "", "Effort level (max, xhigh, high, medium, low). 'xhigh' is Opus 4.7 only; 'max' is Opus 4.6/4.7 only.")
+	rootCmd.PersistentFlags().StringVarP(&config.Effort, flagEffort, "E", "", "Effort level (max, xhigh, high, medium, low). 'xhigh' is Opus 4.7/4.8; 'max' is Opus 4.6/4.7/4.8.")
 	_ = rootCmd.RegisterFlagCompletionFunc(flagEffort,
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return []string{EffortMax, EffortXHigh, EffortHigh, EffortMedium, EffortLow}, cobra.ShellCompDirectiveDefault

--- a/tool_text_editor.go
+++ b/tool_text_editor.go
@@ -99,11 +99,11 @@ func NewTextEditorToolDefinition(model string) TextEditorToolDefinition {
 		toolName = TextEditorToolNameLegacy
 	}
 
-	// Claude 4.x models (including 4.5, 4.6, and 4.7) use the 20250728 version with new name
+	// Claude 4.x models (including 4.5, 4.6, 4.7, and 4.8) use the 20250728 version with new name
 	if modelID == ClaudeV4Sonnet.String() || modelID == ClaudeV4Opus.String() ||
 		modelID == ClaudeV45Sonnet.String() || modelID == ClaudeV45Haiku.String() ||
 		modelID == ClaudeV45Opus.String() || modelID == ClaudeV46Opus.String() ||
-		modelID == ClaudeV47Opus.String() {
+		modelID == ClaudeV47Opus.String() || modelID == ClaudeV48Opus.String() {
 		toolType = TextEditor20250728
 		toolName = TextEditorToolNameNew
 	}

--- a/types.go
+++ b/types.go
@@ -25,6 +25,7 @@ const (
 	ClaudeV46Opus
 	ClaudeV47Opus
 	ClaudeV46Sonnet
+	ClaudeV48Opus
 )
 
 // Roles as defined by the Bedrock Anthropic Model API
@@ -76,7 +77,7 @@ var MessageContentTypes = []string{
 }
 
 func (m AnthropicModel) IsClaude3OrHigherModel() bool {
-	if m == ClaudeV3Sonnet || m == ClaudeV3Haiku || m == ClaudeV3Opus || m == ClaudeV35Sonnet || m == ClaudeV35SonnetV2 || m == ClaudeV37Sonnet || m == ClaudeV4Sonnet || m == ClaudeV4Opus || m == ClaudeV45Sonnet || m == ClaudeV45Haiku || m == ClaudeV45Opus || m == ClaudeV46Opus || m == ClaudeV47Opus || m == ClaudeV46Sonnet {
+	if m == ClaudeV3Sonnet || m == ClaudeV3Haiku || m == ClaudeV3Opus || m == ClaudeV35Sonnet || m == ClaudeV35SonnetV2 || m == ClaudeV37Sonnet || m == ClaudeV4Sonnet || m == ClaudeV4Opus || m == ClaudeV45Sonnet || m == ClaudeV45Haiku || m == ClaudeV45Opus || m == ClaudeV46Opus || m == ClaudeV47Opus || m == ClaudeV46Sonnet || m == ClaudeV48Opus {
 		return true
 	}
 
@@ -119,6 +120,7 @@ func IsClaude3OrHigherModelID(id string) bool {
 		ClaudeV46Opus.String(),
 		ClaudeV47Opus.String(),
 		ClaudeV46Sonnet.String(),
+		ClaudeV48Opus.String(),
 	}
 	modelID := normalizeToModelID(id)
 	return slices.Contains(v3IDs, modelID)
@@ -130,7 +132,7 @@ func IsVisionCapable(id string) bool {
 }
 
 // IsPromptCachingSupported returns true if the given model ID supports prompt caching.
-// Prompt caching is generally available with Claude 3.7 Sonnet, Claude 3.5 Haiku, Claude 4, Claude 4.5, Claude 4.6, and Claude 4.7.
+// Prompt caching is generally available with Claude 3.7 Sonnet, Claude 3.5 Haiku, Claude 4, Claude 4.5, Claude 4.6, Claude 4.7, and Claude 4.8.
 // See: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html#prompt-caching-models
 func IsPromptCachingSupported(id string) bool {
 	modelID := normalizeToModelID(id)
@@ -145,18 +147,19 @@ func IsPromptCachingSupported(id string) bool {
 		ClaudeV46Opus.String(),   // Claude 4.6 Opus
 		ClaudeV47Opus.String(),   // Claude 4.7 Opus
 		ClaudeV46Sonnet.String(), // Claude 4.6 Sonnet
+		ClaudeV48Opus.String(),   // Claude 4.8 Opus
 	}
 	return slices.Contains(cachingSupportedModels, modelID)
 }
 
 // IsEffortParamSupported returns true if the given model ID supports the effort parameter.
-// The effort parameter is supported by Claude Opus 4.5, Claude Opus 4.6, Claude Opus 4.7,
+// The effort parameter is supported by Claude Opus 4.5, Claude Opus 4.6, Claude Opus 4.7, Claude Opus 4.8,
 // and Claude Sonnet 4.6 (which defaults to effort "high"). Note that "xhigh"/"max" remain
 // Opus-only; Sonnet 4.6 accepts "high"/"medium"/"low".
 // See: opus47vision.md ("Migrating to Claude Sonnet 4.6").
 func IsEffortParamSupported(id string) bool {
 	modelID := normalizeToModelID(id)
-	return modelID == ClaudeV45Opus.String() || modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String() || modelID == ClaudeV46Sonnet.String()
+	return modelID == ClaudeV45Opus.String() || modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String() || modelID == ClaudeV46Sonnet.String() || modelID == ClaudeV48Opus.String()
 }
 
 // IsSamplingParamsRejected returns true for models that reject ANY non-default
@@ -166,7 +169,7 @@ func IsEffortParamSupported(id string) bool {
 // See: opus47vision.md ("Sampling parameters removed").
 func IsSamplingParamsRejected(id string) bool {
 	modelID := normalizeToModelID(id)
-	return modelID == ClaudeV47Opus.String()
+	return modelID == ClaudeV47Opus.String() || modelID == ClaudeV48Opus.String()
 }
 
 // IsClaude45OrHigherModel returns true if the given model ID is Claude 4.5+ (Sonnet, Haiku, Opus, or Opus 4.6).
@@ -180,6 +183,7 @@ func IsClaude45OrHigherModel(id string) bool {
 		ClaudeV46Opus.String(),   // Claude 4.6 Opus
 		ClaudeV47Opus.String(),   // Claude 4.7 Opus
 		ClaudeV46Sonnet.String(), // Claude 4.6 Sonnet
+		ClaudeV48Opus.String(),   // Claude 4.8 Opus
 	}
 	return slices.Contains(claude45PlusModels, modelID)
 }
@@ -196,11 +200,17 @@ func IsOpus47Model(id string) bool {
 	return modelID == ClaudeV47Opus.String()
 }
 
+// IsOpus48Model returns true if the given model ID is Claude Opus 4.8.
+func IsOpus48Model(id string) bool {
+	modelID := normalizeToModelID(id)
+	return modelID == ClaudeV48Opus.String()
+}
+
 // IsAdaptiveThinkingModel returns true for models that use adaptive thinking
-// rather than manual budget_tokens (Opus 4.6, Opus 4.7, and Sonnet 4.6).
+// rather than manual budget_tokens (Opus 4.6, Opus 4.7, Opus 4.8, and Sonnet 4.6).
 func IsAdaptiveThinkingModel(id string) bool {
 	modelID := normalizeToModelID(id)
-	return modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String() || modelID == ClaudeV46Sonnet.String()
+	return modelID == ClaudeV46Opus.String() || modelID == ClaudeV47Opus.String() || modelID == ClaudeV46Sonnet.String() || modelID == ClaudeV48Opus.String()
 }
 
 func (m AnthropicModel) String() string {
@@ -235,6 +245,8 @@ func (m AnthropicModel) String() string {
 		return "anthropic.claude-opus-4-7"
 	case ClaudeV46Sonnet:
 		return "anthropic.claude-sonnet-4-6"
+	case ClaudeV48Opus:
+		return "anthropic.claude-opus-4-8"
 	default:
 		panic("AnthropicModel String()  - unhandled default case")
 	}
@@ -258,6 +270,7 @@ var AnthrophicModelsIDs = []string{
 	ClaudeV46Opus.String(),
 	ClaudeV47Opus.String(),
 	ClaudeV46Sonnet.String(),
+	ClaudeV48Opus.String(),
 }
 
 // --- anthropic.claude ----------------------------

--- a/types_test.go
+++ b/types_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 )
 
-const nameClaude47Opus = "Claude 4.7 Opus"
+const (
+	nameClaude47Opus = "Claude 4.7 Opus"
+	nameClaude48Opus = "Claude 4.8 Opus"
+)
 
 func TestIsVisionCapable(t *testing.T) {
 	tests := []struct {
@@ -40,6 +43,11 @@ func TestIsVisionCapable(t *testing.T) {
 		{
 			name:     nameClaude47Opus,
 			modelID:  ClaudeV47Opus.String(),
+			expected: true,
+		},
+		{
+			name:     nameClaude48Opus,
+			modelID:  ClaudeV48Opus.String(),
 			expected: true,
 		},
 	}
@@ -105,6 +113,11 @@ func TestIsPromptCachingSupported(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     nameClaude48Opus,
+			modelID:  ClaudeV48Opus.String(),
+			expected: true,
+		},
+		{
 			name:     "Claude 3 Sonnet (No Caching)",
 			modelID:  ClaudeV3Sonnet.String(),
 			expected: false,
@@ -134,6 +147,16 @@ func TestIsSamplingParamsRejected(t *testing.T) {
 		{
 			name:     "Claude 4.7 Opus (region-prefixed)",
 			modelID:  "eu.anthropic.claude-opus-4-7",
+			expected: true,
+		},
+		{
+			name:     nameClaude48Opus,
+			modelID:  ClaudeV48Opus.String(),
+			expected: true,
+		},
+		{
+			name:     "Claude 4.8 Opus (region-prefixed)",
+			modelID:  "eu.anthropic.claude-opus-4-8",
 			expected: true,
 		},
 		{


### PR DESCRIPTION
  - Add ClaudeV48Opus (anthropic.claude-opus-4-8) across all capability helpers: prompt caching, effort, sampling-params-rejected, adaptive thinking, vision, text editor tool version selection
  - Update default model from Opus 4.7 to Opus 4.8
  - Fix effort-2025-11-24 beta header to only fire for Opus 4.5; Opus 4.6/4.7/4.8 use the effort parameter natively without a beta header
  - Extend xhigh/max effort validation to include Opus 4.8